### PR TITLE
Restructure API for loose coupling of declaration and source

### DIFF
--- a/projects/core/src/main/kotlin/de/gfelbing/konfig/core/definition/KonfigDeclaration.kt
+++ b/projects/core/src/main/kotlin/de/gfelbing/konfig/core/definition/KonfigDeclaration.kt
@@ -75,6 +75,6 @@ abstract class KonfigDeclaration {
     /**
      * Factory method for a [StringParameter].
      */
-    fun string(vararg path: String) = StringParameter(path.asList())
+    fun string(vararg path: String) = StringParameter(path.toList())
 }
 

--- a/projects/core/src/main/kotlin/de/gfelbing/konfig/core/definition/KonfigDeclaration.kt
+++ b/projects/core/src/main/kotlin/de/gfelbing/konfig/core/definition/KonfigDeclaration.kt
@@ -17,9 +17,9 @@
 package de.gfelbing.konfig.core.definition
 
 /**
- * Abstract class for declarations, holding convenience methods.
+ * Base object for declarations, holding convenience methods.
  */
-abstract class KonfigDeclaration {
+object KonfigDeclaration {
     /**
      * Extends [Parameter] to convert it into a non-null [RequiredParameter].
      */

--- a/projects/core/src/main/kotlin/de/gfelbing/konfig/core/definition/Parameter.kt
+++ b/projects/core/src/main/kotlin/de/gfelbing/konfig/core/definition/Parameter.kt
@@ -26,10 +26,30 @@ interface Parameter<T> {
     /**
      * Returns a pair containing the parameter value and a descriptive value which can be used for logging.
      */
-    operator fun invoke(source: KonfigurationSource): Pair<T, String>
+    fun readFrom(source: KonfigurationSource): T
 
     /**
      * The [ParameterDescription] of this parameter.
      */
     fun description(): ParameterDescription
+
+    /**
+     * Wraps a retained value into an appropriate string representation for logging.
+     * Can be used to override secret value behaviour for example.
+     */
+    fun toLoggingString(value: T?): String = value.toDefaultLoggingString()
+
+    /**
+     * Convenience shorthand for obtaining the value of this [Parameter]
+     * from a given [KonfigurationSource].
+     */
+    operator fun invoke(source: KonfigurationSource): T = readFrom(source)
+
+    companion object {
+        const val NULL_LITERAL = "NULL"
+
+        fun <T> T?.toDefaultLoggingString(): String {
+            return this?.let { "'$it'" } ?: NULL_LITERAL
+        }
+    }
 }

--- a/projects/core/src/main/kotlin/de/gfelbing/konfig/core/definition/RequiredParameter.kt
+++ b/projects/core/src/main/kotlin/de/gfelbing/konfig/core/definition/RequiredParameter.kt
@@ -25,10 +25,8 @@ class RequiredParameter<T>(val optionalParameter: Parameter<T?>) : Parameter<T> 
     /**
      * Delegates the invocation to the [optionalParameter] and throws a [KonfigException] if the value is unset.
      */
-    override fun invoke(source: KonfigurationSource) = optionalParameter(source).let { (value, logValue) ->
-        val nonNullValue = value ?: throw KonfigException("Unable to load required parameter ${this.description()}")
-        nonNullValue to logValue
-    }
+    override fun readFrom(source: KonfigurationSource): T = optionalParameter.readFrom(source)
+        ?: throw KonfigException("Unable to load required parameter ${this.description()}")
 
     /**
      * Adds the property 'required' to the parent description.

--- a/projects/core/src/main/kotlin/de/gfelbing/konfig/core/definition/RequiredParameter.kt
+++ b/projects/core/src/main/kotlin/de/gfelbing/konfig/core/definition/RequiredParameter.kt
@@ -27,9 +27,8 @@ class RequiredParameter<T>(val optionalParameter: Parameter<T?>) : Parameter<T> 
      */
     override fun invoke(source: KonfigurationSource) = optionalParameter(source).let { (value, logValue) ->
         val nonNullValue = value ?: throw KonfigException("Unable to load required parameter ${this.description()}")
-        Pair(nonNullValue, logValue)
+        nonNullValue to logValue
     }
-
 
     /**
      * Adds the property 'required' to the parent description.

--- a/projects/core/src/main/kotlin/de/gfelbing/konfig/core/definition/SecretParameter.kt
+++ b/projects/core/src/main/kotlin/de/gfelbing/konfig/core/definition/SecretParameter.kt
@@ -25,7 +25,12 @@ class SecretParameter<T>(val parent: Parameter<T>) : Parameter<T> {
     /**
      * Delegates invocation to [parent], overriding the descriptive value by 'SECRET'.
      */
-    override fun invoke(source: KonfigurationSource) = parent(source).copy(second = "SECRET")
+    override fun readFrom(source: KonfigurationSource): T = parent.readFrom(source)
+
+    /**
+     * Hide any incoming value from evil loggers' eyes.
+     */
+    override fun toLoggingString(value: T?) = SECRET_LITERAL
 
     /**
      * Adds the property 'secret' to [parent] description.
@@ -33,6 +38,10 @@ class SecretParameter<T>(val parent: Parameter<T>) : Parameter<T> {
     override fun description(): ParameterDescription {
         val desc = parent.description()
         return desc.copy(props = desc.props + "secret")
+    }
+
+    companion object {
+        const val SECRET_LITERAL = "SECRET"
     }
 }
 

--- a/projects/core/src/main/kotlin/de/gfelbing/konfig/core/definition/SecretParameter.kt
+++ b/projects/core/src/main/kotlin/de/gfelbing/konfig/core/definition/SecretParameter.kt
@@ -25,9 +25,7 @@ class SecretParameter<T>(val parent: Parameter<T>) : Parameter<T> {
     /**
      * Delegates invocation to [parent], overriding the descriptive value by 'SECRET'.
      */
-    override fun invoke(source: KonfigurationSource) = parent(source).let { (value, _) ->
-        Pair(value, "SECRET")
-    }
+    override fun invoke(source: KonfigurationSource) = parent(source).copy(second = "SECRET")
 
     /**
      * Adds the property 'secret' to [parent] description.

--- a/projects/core/src/main/kotlin/de/gfelbing/konfig/core/definition/StringParameter.kt
+++ b/projects/core/src/main/kotlin/de/gfelbing/konfig/core/definition/StringParameter.kt
@@ -26,9 +26,7 @@ class StringParameter(val path: List<String>) : Parameter<String?> {
     /**
      * Reads the value from [source] and generates a descriptive value.
      */
-    override fun invoke(source: KonfigurationSource) = source.getOptionalString(path).let {
-        Pair(it, it?.let { "'$it'" } ?: "NULL")
-    }
+    override fun readFrom(source: KonfigurationSource): String? = source.getOptionalString(path)
 
     /**
      * Returns the [ParameterDescription] of this parameter.

--- a/projects/core/src/main/kotlin/de/gfelbing/konfig/core/definition/TransformedParameter.kt
+++ b/projects/core/src/main/kotlin/de/gfelbing/konfig/core/definition/TransformedParameter.kt
@@ -34,8 +34,5 @@ class TransformedParameter<V, T>(val parent: Parameter<V>, val typeName: String,
     /**
      * Overrides the type of the [parent] description.
      */
-    override fun description(): ParameterDescription {
-        val parentDescription = parent.description()
-        return parentDescription.copy(typeName = typeName)
-    }
+    override fun description() = parent.description().copy(typeName = typeName)
 }

--- a/projects/core/src/main/kotlin/de/gfelbing/konfig/core/definition/TransformedParameter.kt
+++ b/projects/core/src/main/kotlin/de/gfelbing/konfig/core/definition/TransformedParameter.kt
@@ -26,10 +26,7 @@ class TransformedParameter<V, T>(val parent: Parameter<V>, val typeName: String,
     /**
      * Invokes [parent] and applies the [transform] the the value.
      */
-    override fun invoke(source: KonfigurationSource) = parent(source).let { (value, _) ->
-        val transformedValue = transform(value)
-        Pair(transformedValue, transformedValue?.let { "'$it'" } ?: "NULL")
-    }
+    override fun readFrom(source: KonfigurationSource): T = transform(parent.readFrom(source))
 
     /**
      * Overrides the type of the [parent] description.

--- a/projects/core/src/main/kotlin/de/gfelbing/konfig/core/log/StdoutLog.kt
+++ b/projects/core/src/main/kotlin/de/gfelbing/konfig/core/log/StdoutLog.kt
@@ -17,7 +17,7 @@
 package de.gfelbing.konfig.core.log
 
 object StdoutLog : Log {
-    val isDebug = System.getenv("KONFIG_DEBUG")?.let { it.toLowerCase() == "true" } ?: false
+    val isDebug = System.getenv("KONFIG_DEBUG")?.toBoolean() ?: false
 
     override fun debug(msg: String) {
         if (isDebug) {

--- a/projects/core/src/main/kotlin/de/gfelbing/konfig/core/source/ChainedKonfiguration.kt
+++ b/projects/core/src/main/kotlin/de/gfelbing/konfig/core/source/ChainedKonfiguration.kt
@@ -20,21 +20,21 @@ import de.gfelbing.konfig.core.log.Log
 import de.gfelbing.konfig.core.source.Sources.DEFAULT_LOG
 
 /**
- * Chaines multiple [KonfigurationSource]s.
+ * Chains multiple [KonfigurationSource]s.
  * The first configuration which yields a value is chosen.
  */
 class ChainedKonfiguration(val sources: List<KonfigurationSource>, override val LOG: Log = DEFAULT_LOG) : KonfigurationSource {
 
-    constructor(vararg sources: KonfigurationSource) : this(sources.asList())
+    constructor(vararg sources: KonfigurationSource) : this(sources.toList())
 
-    override fun getOptionalString(path: List<String>) = sources
-            .asSequence()
-            .map { it.getOptionalString(path) }
-            .filterNotNull()
+    override fun getOptionalString(path: List<String>) =
+        sources.asSequence()
+            .mapNotNull { it.getOptionalString(path) }
             .firstOrNull()
 
-    override fun describe(path: List<String>): String? = sources
-            .asSequence()
-            .find { it.getOptionalString(path) != null }
-            ?.let { it.describe(path) }
+    override fun describe(path: List<String>): String? =
+        sources.asSequence()
+            .filter { it.getOptionalString(path) != null }
+            .firstOrNull()
+            ?.describe(path)
 }

--- a/projects/core/src/main/kotlin/de/gfelbing/konfig/core/source/EnvironmentKonfiguration.kt
+++ b/projects/core/src/main/kotlin/de/gfelbing/konfig/core/source/EnvironmentKonfiguration.kt
@@ -23,17 +23,19 @@ import de.gfelbing.konfig.core.log.Log
  */
 class EnvironmentKonfiguration(override val LOG: Log = Sources.DEFAULT_LOG) : KonfigurationSource {
     /**
-     * Generates the environment variable name from the path by joining uppercased elements by '_'.
-     */
-    fun toEnvName(path: List<String>) = path.map { it.toUpperCase() }.joinToString("_")
-
-    /**
      * Reads the environment variable using the naming convention from [toEnvName].
      */
-    override fun getOptionalString(path: List<String>) = System.getenv(toEnvName(path))
+    override fun getOptionalString(path: List<String>): String? = System.getenv(toEnvName(path))
 
     /**
      * Generates a source description.
      */
     override fun describe(path: List<String>) = "ENV(${toEnvName(path)})"
+
+    companion object {
+        /**
+         * Generates the environment variable name from the path by joining uppercased elements by '_'.
+         */
+        fun toEnvName(path: List<String>) = path.joinToString("_") { it.toUpperCase() }
+    }
 }

--- a/projects/core/src/main/kotlin/de/gfelbing/konfig/core/source/EnvironmentKonfiguration.kt
+++ b/projects/core/src/main/kotlin/de/gfelbing/konfig/core/source/EnvironmentKonfiguration.kt
@@ -22,6 +22,7 @@ import de.gfelbing.konfig.core.log.Log
  * Reads values from environment variables.
  */
 class EnvironmentKonfiguration(override val LOG: Log = Sources.DEFAULT_LOG) : KonfigurationSource {
+
     /**
      * Reads the environment variable using the naming convention from [toEnvName].
      */

--- a/projects/core/src/main/kotlin/de/gfelbing/konfig/core/source/KonfigurationSource.kt
+++ b/projects/core/src/main/kotlin/de/gfelbing/konfig/core/source/KonfigurationSource.kt
@@ -48,12 +48,12 @@ interface KonfigurationSource {
 
         LOG.info(listOfNotNull(
                 desc.path.joinToString(".", "config:"),
-                value.second.let { "value:$it" },
+                "value:${parameter.toLoggingString(value)}",
                 "type:${desc.typeName}",
                 desc.props.joinToString(", ", "props:[", "]"),
                 describe(desc.path)?.let { "source:$it" }
         ).joinToString(", "))
 
-        return value.first
+        return value
     }
 }

--- a/projects/core/src/main/kotlin/de/gfelbing/konfig/core/source/KonfigurationSource.kt
+++ b/projects/core/src/main/kotlin/de/gfelbing/konfig/core/source/KonfigurationSource.kt
@@ -45,13 +45,15 @@ interface KonfigurationSource {
     operator fun <T> get(parameter: Parameter<T>): T {
         val desc = parameter.description()
         val value = parameter(this)
-        LOG.info(listOf(
+
+        LOG.info(listOfNotNull(
                 desc.path.joinToString(".", "config:"),
                 value.second.let { "value:$it" },
                 "type:${desc.typeName}",
                 desc.props.joinToString(", ", "props:[", "]"),
                 describe(desc.path)?.let { "source:$it" }
-        ).filterNotNull().joinToString(", "))
+        ).joinToString(", "))
+
         return value.first
     }
 }

--- a/projects/core/src/main/kotlin/de/gfelbing/konfig/core/source/PropertiesFileKonfiguration.kt
+++ b/projects/core/src/main/kotlin/de/gfelbing/konfig/core/source/PropertiesFileKonfiguration.kt
@@ -26,25 +26,6 @@ import java.io.InputStream
  */
 class PropertiesFileKonfiguration(val fileName: String, val input: () -> InputStream, override val LOG: Log = Sources.DEFAULT_LOG) : PropertiesKonfiguration() {
 
-    companion object {
-        /**
-         * Creates an [InputStream] for the given [fileName].
-         */
-        fun getInputStream(filePath: String): InputStream {
-            // First, try to load the file from the file system
-            if (File(filePath).exists()) {
-                return File(filePath).inputStream()
-            }
-            // If this fails, it may be bundled in a jar
-            val systemResourceAsStream = ClassLoader.getSystemResourceAsStream(filePath)
-            if (systemResourceAsStream != null) {
-                return systemResourceAsStream
-            }
-            // Otherwise, fail.
-            throw KonfigException("Unable to load property file '$filePath'.")
-        }
-    }
-
     constructor(filePath: String) : this(filePath, { getInputStream(filePath) })
 
     /**
@@ -65,4 +46,23 @@ class PropertiesFileKonfiguration(val fileName: String, val input: () -> InputSt
      * Generates a descriptive string used for logging.
      */
     override fun describe(path: List<String>) = "PROPERTY($fileName, ${toPropertyName(path)})"
+
+    companion object {
+        /**
+         * Creates an [InputStream] for the given [fileName].
+         */
+        fun getInputStream(filePath: String): InputStream {
+            // First, try to load the file from the file system
+            if (File(filePath).exists()) {
+                return File(filePath).inputStream()
+            }
+            // If this fails, it may be bundled in a jar
+            val systemResourceAsStream = ClassLoader.getSystemResourceAsStream(filePath)
+            if (systemResourceAsStream != null) {
+                return systemResourceAsStream
+            }
+            // Otherwise, fail.
+            throw KonfigException("Unable to load property file '$filePath'.")
+        }
+    }
 }

--- a/projects/core/src/main/kotlin/de/gfelbing/konfig/core/source/PropertiesFileKonfiguration.kt
+++ b/projects/core/src/main/kotlin/de/gfelbing/konfig/core/source/PropertiesFileKonfiguration.kt
@@ -53,16 +53,11 @@ class PropertiesFileKonfiguration(val fileName: String, val input: () -> InputSt
          */
         fun getInputStream(filePath: String): InputStream {
             // First, try to load the file from the file system
-            if (File(filePath).exists()) {
-                return File(filePath).inputStream()
-            }
-            // If this fails, it may be bundled in a jar
-            val systemResourceAsStream = ClassLoader.getSystemResourceAsStream(filePath)
-            if (systemResourceAsStream != null) {
-                return systemResourceAsStream
-            }
-            // Otherwise, fail.
-            throw KonfigException("Unable to load property file '$filePath'.")
+            return File(filePath).takeIf { it.exists() }?.inputStream()
+                // If this fails, it may be bundled in a jar
+                ?: ClassLoader.getSystemResourceAsStream(filePath)
+                // Otherwise, fail.
+                ?: throw KonfigException("")
         }
     }
 }

--- a/projects/core/src/main/kotlin/de/gfelbing/konfig/core/source/PropertiesKonfiguration.kt
+++ b/projects/core/src/main/kotlin/de/gfelbing/konfig/core/source/PropertiesKonfiguration.kt
@@ -27,9 +27,7 @@ abstract class PropertiesKonfiguration(val properties: Properties = Properties()
     /**
      * Reads a value from [properties] using the naming convention from [toPropertyName].
      */
-    override fun getOptionalString(path: List<String>): String? {
-        return properties[toPropertyName(path)]?.let { it as? String } // FIXME checked cast? Rather use toString?
-    }
+    override fun getOptionalString(path: List<String>): String? = properties.getProperty(toPropertyName(path))
 
     /**
      * Generates a descriptive string used for logging.

--- a/projects/core/src/main/kotlin/de/gfelbing/konfig/core/source/PropertiesKonfiguration.kt
+++ b/projects/core/src/main/kotlin/de/gfelbing/konfig/core/source/PropertiesKonfiguration.kt
@@ -23,21 +23,22 @@ import java.util.*
  * Abstract [KonfigurationSource] based on [Properties]. E.g. [PropertiesFileKonfiguration], [SystemPropertiesKonfiguration].
  */
 abstract class PropertiesKonfiguration(val properties: Properties = Properties(), override val LOG: Log = Sources.DEFAULT_LOG) : KonfigurationSource {
-
-    /**
-     * Generates the property name by joining the lowercase path elements with '.'.
-     */
-    fun toPropertyName(path: List<String>) = path.map { it.toLowerCase() }.joinToString(".")
-
     /**
      * Reads a value from [properties] using the naming convention from [toPropertyName].
      */
     override fun getOptionalString(path: List<String>): String? {
-        return properties[toPropertyName(path)]?.let { it as String }
+        return properties[toPropertyName(path)]?.let { it as String } // FIXME unchecked cast? Rather use toString?
     }
 
     /**
      * Generates a descriptive string used for logging.
      */
     override fun describe(path: List<String>): String = "PROPERTY(${toPropertyName(path)})"
+
+    companion object {
+        /**
+         * Generates the property name by joining the lowercase path elements with '.'.
+         */
+        fun toPropertyName(path: List<String>) = path.joinToString(".") { it.toLowerCase() }
+    }
 }

--- a/projects/core/src/main/kotlin/de/gfelbing/konfig/core/source/PropertiesKonfiguration.kt
+++ b/projects/core/src/main/kotlin/de/gfelbing/konfig/core/source/PropertiesKonfiguration.kt
@@ -23,11 +23,12 @@ import java.util.*
  * Abstract [KonfigurationSource] based on [Properties]. E.g. [PropertiesFileKonfiguration], [SystemPropertiesKonfiguration].
  */
 abstract class PropertiesKonfiguration(val properties: Properties = Properties(), override val LOG: Log = Sources.DEFAULT_LOG) : KonfigurationSource {
+
     /**
      * Reads a value from [properties] using the naming convention from [toPropertyName].
      */
     override fun getOptionalString(path: List<String>): String? {
-        return properties[toPropertyName(path)]?.let { it as String } // FIXME unchecked cast? Rather use toString?
+        return properties[toPropertyName(path)]?.let { it as? String } // FIXME checked cast? Rather use toString?
     }
 
     /**

--- a/projects/core/src/main/kotlin/de/gfelbing/konfig/core/source/Sources.kt
+++ b/projects/core/src/main/kotlin/de/gfelbing/konfig/core/source/Sources.kt
@@ -22,6 +22,7 @@ import de.gfelbing.konfig.core.log.StdoutLog
  * Utility for [KonfigurationSource]s.
  */
 object Sources {
+
     /**
      * The default log used by the [KonfigurationSource]s.
      */

--- a/projects/core/src/test/kotlin/de/gfelbing/konfig/core/definition/KonfigDeclarationTest.kt
+++ b/projects/core/src/test/kotlin/de/gfelbing/konfig/core/definition/KonfigDeclarationTest.kt
@@ -16,6 +16,16 @@
 
 package de.gfelbing.konfig.core.definition
 
+import de.gfelbing.konfig.core.definition.KonfigDeclaration.string
+import de.gfelbing.konfig.core.definition.KonfigDeclaration.double
+import de.gfelbing.konfig.core.definition.KonfigDeclaration.long
+import de.gfelbing.konfig.core.definition.KonfigDeclaration.int
+import de.gfelbing.konfig.core.definition.KonfigDeclaration.byte
+import de.gfelbing.konfig.core.definition.KonfigDeclaration.short
+import de.gfelbing.konfig.core.definition.KonfigDeclaration.float
+import de.gfelbing.konfig.core.definition.KonfigDeclaration.boolean
+import de.gfelbing.konfig.core.definition.KonfigDeclaration.secret
+import de.gfelbing.konfig.core.definition.KonfigDeclaration.required
 import de.gfelbing.konfig.core.source.KonfigurationSource
 import de.gfelbing.konfig.core.source.SystemPropertiesKonfiguration
 import org.hamcrest.MatcherAssert.assertThat
@@ -24,7 +34,7 @@ import org.testng.annotations.Test
 
 class KonfigDeclarationTest {
 
-    object TestConfigDeclaration : KonfigDeclaration() {
+    object TestConfigDeclaration {
         val optionalDouble = double("optional", "double")
         val optionalString = string("optional", "string")
         val requiredLong = long("required", "long").required()

--- a/projects/examples/src/main/kotlin/de/gfelbing/konfig/examples/hello/MyConfigDeclaration.kt
+++ b/projects/examples/src/main/kotlin/de/gfelbing/konfig/examples/hello/MyConfigDeclaration.kt
@@ -16,7 +16,12 @@
 
 package de.gfelbing.konfig.examples.hello
 
-import de.gfelbing.konfig.core.definition.KonfigDeclaration
+import de.gfelbing.konfig.core.definition.KonfigDeclaration.double
+import de.gfelbing.konfig.core.definition.KonfigDeclaration.int
+import de.gfelbing.konfig.core.definition.KonfigDeclaration.long
+import de.gfelbing.konfig.core.definition.KonfigDeclaration.string
+import de.gfelbing.konfig.core.definition.KonfigDeclaration.required
+import de.gfelbing.konfig.core.definition.KonfigDeclaration.secret
 import de.gfelbing.konfig.core.source.KonfigurationSource
 
 /**
@@ -24,7 +29,7 @@ import de.gfelbing.konfig.core.source.KonfigurationSource
  *
  * @author gfelbing@github.com
  */
-object MyConfigDeclaration : KonfigDeclaration() {
+object MyConfigDeclaration {
     val requiredString = string("required", "string").required()
     val optionalString = string("optional", "string")
     val optionalInt = int("optional", "int")

--- a/projects/examples/src/main/kotlin/de/gfelbing/konfig/examples/host/HostBasedConfigDeclaration.kt
+++ b/projects/examples/src/main/kotlin/de/gfelbing/konfig/examples/host/HostBasedConfigDeclaration.kt
@@ -16,10 +16,11 @@
 
 package de.gfelbing.konfig.examples.host
 
-import de.gfelbing.konfig.core.definition.KonfigDeclaration
+import de.gfelbing.konfig.core.definition.KonfigDeclaration.string
+import de.gfelbing.konfig.core.definition.KonfigDeclaration.required
 import de.gfelbing.konfig.core.source.KonfigurationSource
 
-object HostBasedConfigDeclaration : KonfigDeclaration() {
+object HostBasedConfigDeclaration {
     val valueA = string("value", "a").required()
     val valueB = string("value", "b").required()
 


### PR DESCRIPTION
## PR highlights:
- `invoke` has been redirected to serve as an alias to `readFrom`. I personally find it way more intuitive to implement a method called `readFrom` as opposed to being confronted with `invoke` when adding your interface to my class
- `readFrom` does not return a `Pair<T, String>` any more. Stringification for logging has been refactored out.
- `asList` on Arrays has been replaced by `toList`. The reason for this change is that the former is a JVM-specific method that retains a reference on the backing array, whereas the latter is a backend-agnostic, "kotlin-esque" approach.

### A few more notes:
- Some behavio(u)r was refactored to `companion object`, especially the methods joining a path into specific key formats
- Tests still succeed just fine.