### PR TITLE
Add default value parameters

### DIFF
--- a/projects/core/src/main/kotlin/de/gfelbing/konfig/core/definition/DefaultComputationParameter.kt
+++ b/projects/core/src/main/kotlin/de/gfelbing/konfig/core/definition/DefaultComputationParameter.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2019 Georg Felbinger
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package de.gfelbing.konfig.core.definition
+
+/**
+ * Transforms a nullable parameter into an non-null parameter by assuming a default value
+ * which is computed on demand (i.e. only if the actual parameter is not present)
+ */
+class DefaultComputationParameter<T>(optionalParameter: Parameter<T?>, val default: () -> T) : WrappedOptionalParameter<T>(optionalParameter) {
+    /**
+     * Computes the default value only when necessary (i.e. when this method is called at all).
+     */
+    override fun handleAbsentParameter() = default()
+
+    /**
+     * Adds a tag to the description indicating that a default value is being used.
+     *
+     * This default value is not unpacked here, in order not to accidentally call
+     * any computationally expensive functions
+     */
+    override val additionalDescriptionProperties = listOf("computedDefault")
+}

--- a/projects/core/src/main/kotlin/de/gfelbing/konfig/core/definition/DefaultValueParameter.kt
+++ b/projects/core/src/main/kotlin/de/gfelbing/konfig/core/definition/DefaultValueParameter.kt
@@ -17,18 +17,19 @@
 package de.gfelbing.konfig.core.definition
 
 /**
- * Transforms a nullable parameter into an non-null parameter by assertion at invokation.
+ * Transforms a nullable parameter into an non-null parameter by assuming a static default value.
  */
-class RequiredParameter<T>(optionalParameter: Parameter<T?>) : WrappedOptionalParameter<T>(optionalParameter) {
+class DefaultValueParameter<T>(optionalParameter: Parameter<T?>, val default: T) : WrappedOptionalParameter<T>(optionalParameter) {
     /**
-     * Throws a [KonfigException] if the value is unset.
+     * Yields the static default value.
      */
-    override fun handleAbsentParameter() =
-        throw KonfigException("Unable to load required parameter ${this.description()}")
+    override fun handleAbsentParameter() = default
 
     /**
-     * Adds a tag to the parameter description indicating that this parameter is required.
+     * Adds a tag to the description indicating that a default value is being used.
+     *
+     * This default value is wrapped inside the logging habits of the wrapped parameter,
+     * such that i.e. secret parameters get masked accordingly.
      */
-    override val additionalDescriptionProperties = listOf("required")
+    override val additionalDescriptionProperties = listOf("default:${toLoggingString(default)}")
 }
-

--- a/projects/core/src/main/kotlin/de/gfelbing/konfig/core/definition/KonfigDeclaration.kt
+++ b/projects/core/src/main/kotlin/de/gfelbing/konfig/core/definition/KonfigDeclaration.kt
@@ -26,6 +26,16 @@ object KonfigDeclaration {
     fun <T> Parameter<T?>.required() = RequiredParameter(this)
 
     /**
+     * Extends [Parameter] to convert it into a [DefaultComputationParameter] with the provided default value getter.
+     */
+    fun <T> Parameter<T?>.lazyDefault(defaultGetter: () -> T) = DefaultComputationParameter(this, defaultGetter)
+
+    /**
+     * Extends [Parameter] to convert it into a [DefaultValueParameter] with the provided default constant value.
+     */
+    fun <T> Parameter<T?>.default(defaultValue: T) = DefaultValueParameter(this, defaultValue)
+
+    /**
      * Extends [Parameter] to convert it into a [SecretParameter].
      */
     fun <T> Parameter<T?>.secret() = SecretParameter(this)

--- a/projects/core/src/main/kotlin/de/gfelbing/konfig/core/definition/WrappedOptionalParameter.kt
+++ b/projects/core/src/main/kotlin/de/gfelbing/konfig/core/definition/WrappedOptionalParameter.kt
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2019 Georg Felbinger
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package de.gfelbing.konfig.core.definition
+
+import de.gfelbing.konfig.core.source.KonfigurationSource
+
+/**
+ * Wraps a nullable parameter into an non-null parameter by assuming some abstract behaviour
+ * that has to be implemented by subclasses.
+ */
+abstract class WrappedOptionalParameter<T>(val optionalParameter: Parameter<T?>) : Parameter<T> {
+    /**
+     * Delegates the invocation to the [optionalParameter] and executes some behaviour
+     * (specified via [handleAbsentParameter]) if it is not present in the original source
+     */
+    override fun readFrom(source: KonfigurationSource): T = optionalParameter.readFrom(source)
+        ?: handleAbsentParameter()
+
+    /**
+     * Injects the behaviour that is desired for when a configuration string
+     * cannot be found in the original source.
+     */
+    abstract fun handleAbsentParameter(): T
+
+    /**
+     * Delegates the invocation to the wrapped parameter.
+     *
+     * This is mostly interesting when SecretParameter is wrapped, such that the
+     * confidentiality is retained when logging.
+     */
+    override fun toLoggingString(value: T?) = optionalParameter.toLoggingString(value)
+
+    /**
+     * Adds the property 'required' to the parent description.
+     */
+    override fun description(): ParameterDescription {
+        val parentDescription = optionalParameter.description()
+        return parentDescription.copy(props = parentDescription.props + additionalDescriptionProperties)
+    }
+
+    /**
+     * Defines additional properties to be used as flags during the logging description process.
+     */
+    abstract val additionalDescriptionProperties: List<String>
+}

--- a/projects/core/src/test/kotlin/de/gfelbing/konfig/core/definition/KonfigDeclarationTest.kt
+++ b/projects/core/src/test/kotlin/de/gfelbing/konfig/core/definition/KonfigDeclarationTest.kt
@@ -26,6 +26,8 @@ import de.gfelbing.konfig.core.definition.KonfigDeclaration.float
 import de.gfelbing.konfig.core.definition.KonfigDeclaration.boolean
 import de.gfelbing.konfig.core.definition.KonfigDeclaration.secret
 import de.gfelbing.konfig.core.definition.KonfigDeclaration.required
+import de.gfelbing.konfig.core.definition.KonfigDeclaration.default
+import de.gfelbing.konfig.core.definition.KonfigDeclaration.lazyDefault
 import de.gfelbing.konfig.core.source.KonfigurationSource
 import de.gfelbing.konfig.core.source.SystemPropertiesKonfiguration
 import org.hamcrest.MatcherAssert.assertThat
@@ -50,6 +52,9 @@ class KonfigDeclarationTest {
 
         val boolean = boolean("boolean")
 
+        val defaultString = string("default", "string").default("maybe")
+        val defaultLazyInt = int("default", "int").lazyDefault { 40 + 2 }
+
         fun load(source: KonfigurationSource) = TestConfig(
                 optionalDouble = source[optionalDouble],
                 optionalString = source[optionalString],
@@ -61,7 +66,9 @@ class KonfigDeclarationTest {
                 long = source[long],
                 double = source[double],
                 float = source[float],
-                boolean = source[boolean]
+                boolean = source[boolean],
+                defaultString = source[defaultString],
+                defaultLazyInt = source[defaultLazyInt]
         )
     }
 
@@ -76,7 +83,9 @@ class KonfigDeclarationTest {
             val long: Long?,
             val double: Double?,
             val float: Float?,
-            val boolean: Boolean?
+            val boolean: Boolean?,
+            val defaultString: String,
+            val defaultLazyInt: Int
     )
 
     @Test
@@ -92,7 +101,9 @@ class KonfigDeclarationTest {
                 long = -4,
                 double = 1.2,
                 float = 2.3F,
-                boolean = true
+                boolean = true,
+                defaultString = "maybe",
+                defaultLazyInt = 42
         )
 
         System.setProperty("optional.double", expectedConfig.optionalDouble.toString())
@@ -108,6 +119,11 @@ class KonfigDeclarationTest {
         System.setProperty("float", expectedConfig.float.toString())
 
         System.setProperty("boolean", expectedConfig.boolean.toString())
+
+        // Default values are derived through the fallback functionality
+        
+        // System.setProperty("default.string", expectedConfig.defaultString)
+        // System.setProperty("default.int", expectedConfig.defaultLazyInt.toString())
 
         val config = TestConfigDeclaration.load(SystemPropertiesKonfiguration())
 


### PR DESCRIPTION
Instead of relying on nullability and null-safe calls, this feature enables the user to specify fallback/default values right within the parameter declaration itself.