### PR TITLE
Introduce sources with namespaces

### DIFF
--- a/projects/core/src/main/kotlin/de/gfelbing/konfig/core/source/NamespacedKonfiguration.kt
+++ b/projects/core/src/main/kotlin/de/gfelbing/konfig/core/source/NamespacedKonfiguration.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2019 Georg Felbinger
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package de.gfelbing.konfig.core.source
+
+import de.gfelbing.konfig.core.log.Log
+
+/**
+ * A [KonfigurationSource] that automatically wraps incoming read requests
+ * into a certain [namespace], such that common key parts can be shared.
+ *
+ * val source = EnvironmentKonfiguration()
+ * val namespaceSource = NamespacedKonfiguration(source, "my", "namespace")
+ *
+ * -->
+ * namespaceSource[string("foo", "bar")] reads ("my", "namespace", "foo", "bar")
+ */
+class NamespacedKonfiguration(val originalSource: KonfigurationSource, vararg val namespace: String, override val LOG: Log = Sources.DEFAULT_LOG) : KonfigurationSource {
+    override fun getOptionalString(path: List<String>) =
+        originalSource.getOptionalString(namespacedPath(path))
+
+    override fun describe(path: List<String>) =
+        originalSource.describe(namespacedPath(path))
+
+    /**
+     * Append the actual request path to the general namespace of this source.
+     */
+    private fun namespacedPath(path: List<String>) = namespace.asList() + path
+}

--- a/projects/core/src/main/kotlin/de/gfelbing/konfig/core/source/Sources.kt
+++ b/projects/core/src/main/kotlin/de/gfelbing/konfig/core/source/Sources.kt
@@ -27,4 +27,10 @@ object Sources {
      * The default log used by the [KonfigurationSource]s.
      */
     var DEFAULT_LOG = StdoutLog
+
+    /**
+     * Extend a configuration over a certain namespace.
+     * Factory method for [NamespacedKonfiguration].
+     */
+    fun KonfigurationSource.withNamespace(vararg namespace: String) = NamespacedKonfiguration(this, *namespace, LOG = this.LOG)
 }

--- a/projects/core/src/test/kotlin/de/gfelbing/konfig/core/source/NamespacedKonfigurationTest.kt
+++ b/projects/core/src/test/kotlin/de/gfelbing/konfig/core/source/NamespacedKonfigurationTest.kt
@@ -1,0 +1,70 @@
+package de.gfelbing.konfig.core.source
+
+import de.gfelbing.konfig.core.definition.KonfigDeclaration.int
+import de.gfelbing.konfig.core.definition.KonfigDeclaration.string
+import de.gfelbing.konfig.core.definition.KonfigDeclaration.required
+import de.gfelbing.konfig.core.source.Sources.withNamespace
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.`is`
+import org.testng.annotations.Test
+
+class NamespacedKonfigurationTest {
+    data class ComplexConfiguration(
+        val hisConfig: NamespaceConfiguration,
+        val herConfig: NamespaceConfiguration
+    ) {
+        companion object {
+            const val NAMESPACE_HIS = "his"
+            const val NAMESPACE_HER = "her"
+
+            fun load(source: KonfigurationSource): ComplexConfiguration {
+                return ComplexConfiguration(
+                    hisConfig = NamespaceConfiguration.load(source.withNamespace(NAMESPACE_HIS)),
+                    herConfig = NamespaceConfiguration.load(source.withNamespace(NAMESPACE_HER))
+                )
+            }
+        }
+    }
+
+    data class NamespaceConfiguration(
+        val someKey: String,
+        val someValue: Int
+    ) {
+        companion object {
+            val someKey = string("some", "key").required()
+            val someValue = int("some", "value").required()
+
+            fun load(source: KonfigurationSource): NamespaceConfiguration {
+                return NamespaceConfiguration(
+                    someKey = source[someKey],
+                    someValue = source[someValue]
+                )
+            }
+        }
+    }
+
+    @Test
+    fun testRead() {
+        val expectedConfiguration = ComplexConfiguration(
+            hisConfig = NamespaceConfiguration(
+                someKey = "foo",
+                someValue = 123
+            ),
+            herConfig = NamespaceConfiguration(
+                someKey = "bar",
+                someValue = 456
+            )
+        )
+
+        System.setProperty("his.some.key", expectedConfiguration.hisConfig.someKey)
+        System.setProperty("his.some.value", expectedConfiguration.hisConfig.someValue.toString())
+
+        System.setProperty("her.some.key", expectedConfiguration.herConfig.someKey)
+        System.setProperty("her.some.value", expectedConfiguration.herConfig.someValue.toString())
+
+        val source = SystemPropertiesKonfiguration()
+        val config = ComplexConfiguration.load(source)
+
+        assertThat(config, `is`(expectedConfiguration))
+    }
+}


### PR DESCRIPTION
A `NamespacedKonfiguration` prefixes all access keys, so that the same type of configuration declaration can be used for different "groups" of keys inside a file.

See the added test for a (made-up) use case example.