### PR TITLE
Add enum getter shorthand

### DIFF
--- a/projects/core/src/main/kotlin/de/gfelbing/konfig/core/definition/KonfigDeclaration.kt
+++ b/projects/core/src/main/kotlin/de/gfelbing/konfig/core/definition/KonfigDeclaration.kt
@@ -94,6 +94,15 @@ object KonfigDeclaration {
     }
 
     /**
+     * Factory method for an enum parameter.
+     *
+     * Inlined in order to be able to reify the type of <E> at runtime.
+     */
+    inline fun <reified E: Enum<E>> enum(vararg path: String) = TransformedParameter(string(*path), "Enum:${E::class}") {
+        it?.let { name -> enumValueOf<E>(name) }
+    }
+
+    /**
      * Factory method for a [StringParameter].
      */
     fun string(vararg path: String) = StringParameter(path.toList())

--- a/projects/core/src/test/kotlin/de/gfelbing/konfig/core/definition/KonfigDeclarationTest.kt
+++ b/projects/core/src/test/kotlin/de/gfelbing/konfig/core/definition/KonfigDeclarationTest.kt
@@ -28,6 +28,7 @@ import de.gfelbing.konfig.core.definition.KonfigDeclaration.secret
 import de.gfelbing.konfig.core.definition.KonfigDeclaration.required
 import de.gfelbing.konfig.core.definition.KonfigDeclaration.default
 import de.gfelbing.konfig.core.definition.KonfigDeclaration.lazyDefault
+import de.gfelbing.konfig.core.definition.KonfigDeclaration.enum
 import de.gfelbing.konfig.core.source.KonfigurationSource
 import de.gfelbing.konfig.core.source.SystemPropertiesKonfiguration
 import org.hamcrest.MatcherAssert.assertThat
@@ -35,6 +36,10 @@ import org.hamcrest.Matchers.`is`
 import org.testng.annotations.Test
 
 class KonfigDeclarationTest {
+
+    enum class Dummy {
+        FOO, BAR, BAZ
+    }
 
     object TestConfigDeclaration {
         val optionalDouble = double("optional", "double")
@@ -55,6 +60,9 @@ class KonfigDeclarationTest {
         val defaultString = string("default", "string").default("maybe")
         val defaultLazyInt = int("default", "int").lazyDefault { 40 + 2 }
 
+        val dummy = enum<Dummy>("dummy").required()
+        val dummyNullable = enum<Dummy>("dummy", "nullable")
+
         fun load(source: KonfigurationSource) = TestConfig(
                 optionalDouble = source[optionalDouble],
                 optionalString = source[optionalString],
@@ -68,7 +76,9 @@ class KonfigDeclarationTest {
                 float = source[float],
                 boolean = source[boolean],
                 defaultString = source[defaultString],
-                defaultLazyInt = source[defaultLazyInt]
+                defaultLazyInt = source[defaultLazyInt],
+                dummy = source[dummy],
+                dummyNullable = source[dummyNullable]
         )
     }
 
@@ -85,7 +95,9 @@ class KonfigDeclarationTest {
             val float: Float?,
             val boolean: Boolean?,
             val defaultString: String,
-            val defaultLazyInt: Int
+            val defaultLazyInt: Int,
+            val dummy: Dummy,
+            val dummyNullable: Dummy?
     )
 
     @Test
@@ -103,7 +115,9 @@ class KonfigDeclarationTest {
                 float = 2.3F,
                 boolean = true,
                 defaultString = "maybe",
-                defaultLazyInt = 42
+                defaultLazyInt = 42,
+                dummy = Dummy.FOO,
+                dummyNullable = Dummy.BAR
         )
 
         System.setProperty("optional.double", expectedConfig.optionalDouble.toString())
@@ -124,6 +138,9 @@ class KonfigDeclarationTest {
         
         // System.setProperty("default.string", expectedConfig.defaultString)
         // System.setProperty("default.int", expectedConfig.defaultLazyInt.toString())
+
+        System.setProperty("dummy", expectedConfig.dummy.name)
+        System.setProperty("dummy.nullable", expectedConfig.dummyNullable?.name.toString())
 
         val config = TestConfigDeclaration.load(SystemPropertiesKonfiguration())
 


### PR DESCRIPTION
Kotlin has a very convenient way of converting a `String` into the enum constant of that same name.

We extend upon `KonfigrationSource` with a second getter method, to wrap call results into an enum conveniently.

## Why no `EnumParameter`?
Short answer: Project Valhalla.
Long answer: When defining a class `class EnumParameter<E: Enum<E>>` the type `E` gets *erased* at runtime. This means that it is **not** possible to reify the generic parameter at runtime (although this would be required by the enum loading structure - see enumValueOf` in the Kotlin stdlib).

### Alternative
Creating a class along the lines of `class EnumParameter<E: Enum<E>>(enum: Class<E>)` that loads the enum constants via reflection black magic. I would rather not include this bulky dependency only for the sake of having an `EnumParameter` available.