### PR TITLE
Add LOG parameter to overloaded KonfigSource constructors

### DIFF
--- a/projects/core/src/main/kotlin/de/gfelbing/konfig/core/source/ChainedKonfiguration.kt
+++ b/projects/core/src/main/kotlin/de/gfelbing/konfig/core/source/ChainedKonfiguration.kt
@@ -25,7 +25,7 @@ import de.gfelbing.konfig.core.source.Sources.DEFAULT_LOG
  */
 class ChainedKonfiguration(val sources: List<KonfigurationSource>, override val LOG: Log = DEFAULT_LOG) : KonfigurationSource {
 
-    constructor(vararg sources: KonfigurationSource) : this(sources.toList())
+    constructor(vararg sources: KonfigurationSource, log: Log = DEFAULT_LOG) : this(sources.toList(), log)
 
     override fun getOptionalString(path: List<String>) =
         sources.asSequence()

--- a/projects/core/src/main/kotlin/de/gfelbing/konfig/core/source/PropertiesFileKonfiguration.kt
+++ b/projects/core/src/main/kotlin/de/gfelbing/konfig/core/source/PropertiesFileKonfiguration.kt
@@ -26,7 +26,7 @@ import java.io.InputStream
  */
 class PropertiesFileKonfiguration(val fileName: String, val input: () -> InputStream, override val LOG: Log = Sources.DEFAULT_LOG) : PropertiesKonfiguration() {
 
-    constructor(filePath: String) : this(filePath, { getInputStream(filePath) })
+    constructor(filePath: String, log: Log = Sources.DEFAULT_LOG) : this(filePath, { getInputStream(filePath) }, log)
 
     /**
      * Initial update of the properties.


### PR DESCRIPTION
You should be able to install your own custom logger even when using "convenience constructors" for some `KonfigurationSource` classes