### PR TITLE
More verbose logging

### DIFF
--- a/projects/core/src/main/kotlin/de/gfelbing/konfig/core/source/NamespacedKonfiguration.kt
+++ b/projects/core/src/main/kotlin/de/gfelbing/konfig/core/source/NamespacedKonfiguration.kt
@@ -32,8 +32,7 @@ class NamespacedKonfiguration(val originalSource: KonfigurationSource, vararg va
     override fun getOptionalString(path: List<String>) =
         originalSource.getOptionalString(namespacedPath(path))
 
-    override fun describe(path: List<String>) =
-        originalSource.describe(namespacedPath(path))
+    override fun describe(path: List<String>) = "NAMESPACE($namespace, ${originalSource.describe(path)})"
 
     /**
      * Append the actual request path to the general namespace of this source.


### PR DESCRIPTION
Add a second layer of logging. The rationale behind doubling the log volume is as follows:
- The framework allows to load from different sourced stacked on top of each other (cf. `ChainedKonfigurationSource`)
- The framework allows transforming string values loaded from a "plain" source, where the transforming methods may throw errors.
- In a case where errors are thrown, a user may wish to know where the library was attempting to load from

In particular, with multi-layered setups loading an Int (where Kotlin stdlib just calls Integer.parseInt at some point) the code may fail with a stacktrace that only reveals "Couldn't parse `foobar` as an Int". It is very hard (aka impossible) to debug currently where the configuration was trying to draw the value `foobar` from in the first place.

This commit aims to fix that by making loading more explicit.